### PR TITLE
DM-29887: HexapodCsc: bug fix: move and offset commands

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,23 @@
 Version History
 ###############
 
+v0.17.1
+-------
+
+Changes:
+
+* This version requires ts_hexrotcomm 0.18.
+* `CscHexapod` bug fix: the ``move`` and ``offset`` commands were rejected if actuators were moving.
+* `CscHexapod` bug fix: ``stop``, ``move``, and ``offset`` still did not reliably interrupt a move.
+
+Requires:
+
+* ts_hexrotcomm 0.18
+* ts_salobj 6.3
+* ts_idl 2.2
+* ts_xml 7.1
+* MTHexapod, MTMount, and MTRotator IDL files, e.g. made using ``make_idl_files.py MTHexapod MTMount MTRotator``
+
 v0.17.0
 -------
 

--- a/python/lsst/ts/mthexapod/hexapod_commander.py
+++ b/python/lsst/ts/mthexapod/hexapod_commander.py
@@ -30,18 +30,6 @@ from . import enums
 STD_TIMEOUT = 5  # timeout for command ack
 
 
-def as_bool(value):
-    """Return a string cast to a bool.
-
-    The following are false: 0, f, false
-    The following are true: 1, t, true
-    No other values are valid.
-    """
-    return {"0": False, "f": False, "false": False, "1": True, "t": True, "true": True}[
-        value
-    ]
-
-
 class HexapodCommander(salobj.CscCommander):
     """Command the MTHexapod CSC from the command line.
 

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -550,7 +550,7 @@ class HexapodCsc(hexrotcomm.BaseCsc):
         If compensation mode is off we do not test compensated position,
         as it allows running with invalid compensation coefficients or inputs.
         """
-        self.assert_enabled_substate(EnabledSubstate.STATIONARY)
+        self.assert_enabled()
         uncompensated_pos = base.Position.from_struct(data)
 
         # Check the new position _before_ cancelling the current move (if any)
@@ -572,7 +572,7 @@ class HexapodCsc(hexrotcomm.BaseCsc):
 
         See note for do_move regarding checking the target position.
         """
-        self.assert_enabled_substate(EnabledSubstate.STATIONARY)
+        self.assert_enabled()
         curr_uncompensated_pos = self._get_uncompensated_position()
         offset = base.Position.from_struct(data)
         uncompensated_pos = curr_uncompensated_pos + offset
@@ -635,8 +635,7 @@ class HexapodCsc(hexrotcomm.BaseCsc):
 
     async def do_stop(self, data):
         """Halt tracking or any other motion."""
-        if self.summary_state != salobj.State.ENABLED:
-            raise salobj.ExpectedError("Not enabled")
+        self.assert_enabled()
         await self.run_command(
             code=enums.CommandCode.SET_ENABLED_SUBSTATE,
             param1=enums.SetEnabledSubstateParam.STOP,

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -910,8 +910,10 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
                 topic=self.remote.evt_compensationMode, enabled=False
             )
 
-    async def test_move_interrupt_move(self):
-        """Test that one move can interrupt another."""
+    async def test_move_interrupt_move_after_delay(self):
+        """Test that one move can interrupt another
+        after the first move is reported to have begun.
+        """
         positions_data = (
             (0, 0, -1000, 0, 0, 0),
             (0, 0, 1000, 0, 0, 0),
@@ -974,6 +976,64 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
                 flush=True, timeout=STD_TIMEOUT
             )
             self.assert_positions_close(data.demand, desired_position)
+
+    async def test_move_interrupt_move_immediately(self):
+        """Test that one move can interrupt another right away."""
+        positions_data = (
+            (0, 0, -1000, 0, 0, 0),
+            (0, 0, 1000, 0, 0, 0),
+            (0, 0, -400, 0, 0, 0),
+        )
+        positions = [mthexapod.Position(*data) for data in positions_data]
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=local_config_dir,
+            settings_to_apply="valid.yaml",
+            simulation_mode=1,
+        ):
+            await self.assert_next_sample(
+                topic=self.remote.evt_compensationMode, enabled=False
+            )
+
+            await self.assert_next_application(desired_position=ZERO_POSITION)
+            await self.assert_next_sample(
+                self.remote.evt_controllerState,
+                controllerState=ControllerState.ENABLED,
+                enabledSubstate=EnabledSubstate.STATIONARY,
+            )
+            move_tasks = []
+            for position in positions:
+                print("command a move")
+                move_tasks.append(
+                    asyncio.create_task(
+                        self.remote.cmd_move.set_start(
+                            **vars(position), timeout=STD_TIMEOUT
+                        )
+                    )
+                )
+                # Give the CSC a chance to start processing the command
+                await asyncio.sleep(0)
+
+            # Wait for the final move task to finish
+            await move_tasks[-1]
+            # The other move tasks should also be done
+            # (if I was quick enough then they should have raised an AckError,
+            # but it's hard to run the test fast enough for that)
+            for task in move_tasks[0:-1]:
+                assert task.done()
+
+            # Give the mock controller telemetry loop some time
+            await asyncio.sleep(self.csc.mock_ctrl.telemetry_interval * 3)
+
+            # Make sure the commanded position is indeed the last position.
+            desired_position = positions[-1]
+            self.assert_positions_close(
+                self.csc.mock_ctrl.telemetry.commanded_pos, desired_position
+            )
+
+            # Do not test the controllerState event because it is
+            # uncertain how many transitions will have occurred
+            # during the consecutive moves.
 
     async def test_offset_no_compensation(self):
         """Test offset with compensation disabled."""
@@ -1079,8 +1139,8 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             for name in axis_names:
                 self.assertAlmostEqual(new_pivot[name], commanded_pivot[name])
 
-    async def test_stop_move(self):
-        """Test stopping a point to point move."""
+    async def test_stop_move_after_delay(self):
+        """Test stopping a move after giving it time to start."""
         # Command a move that moves all actuators equally
         position = mthexapod.Position(0, 0, 1000, 0, 0, 0)
         async with self.make_csc(initial_state=salobj.State.ENABLED, simulation_mode=1):
@@ -1121,6 +1181,61 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             ]
             for i in range(6):
                 self.assertNotAlmostEqual(cmd_lengths[i], stopped_lengths[i])
+
+    async def test_stop_move_immediately(self):
+        """Test that stop can interrupt a move right away."""
+        position = copy.copy(ZERO_POSITION)
+        position.z = 1000
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=local_config_dir,
+            settings_to_apply="valid.yaml",
+            simulation_mode=1,
+        ):
+            self.csc.log.level = 10
+            await self.assert_next_sample(
+                topic=self.remote.evt_compensationMode, enabled=False
+            )
+
+            await self.assert_next_application(desired_position=ZERO_POSITION)
+            await self.assert_next_sample(
+                self.remote.evt_controllerState,
+                controllerState=ControllerState.ENABLED,
+                enabledSubstate=EnabledSubstate.STATIONARY,
+            )
+            move_task = asyncio.create_task(
+                self.remote.cmd_move.set_start(**vars(position), timeout=STD_TIMEOUT)
+            )
+
+            # Give the CSC a chance to start processing the command
+            await asyncio.sleep(0.1)
+
+            await self.remote.cmd_stop.start(timeout=STD_TIMEOUT)
+            await asyncio.sleep(0)
+            self.assertTrue(move_task.done())
+
+            # Give the mock controller telemetry loop some time
+            await asyncio.sleep(self.csc.mock_ctrl.telemetry_interval * 3)
+
+            # Make sure the commanded position is indeed the last position
+            # (in other words: that the move command was actually sent
+            # to the low-level controller).
+            self.assert_positions_close(
+                self.csc.mock_ctrl.telemetry.commanded_pos, position
+            )
+
+            # Make sure the controller is stopped
+            self.assertEqual(
+                self.csc.mock_ctrl.telemetry.state,
+                ControllerState.ENABLED,
+            )
+            self.assertEqual(
+                self.csc.mock_ctrl.telemetry.enabled_substate,
+                EnabledSubstate.STATIONARY,
+            )
+
+            # Do not test the controllerState event because it is
+            # uncertain how many transitions will have occurred.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow move and offset commands while moving. There was already
code to stop the current move but it was never run because
of an incorrect initial assert in the do_move and do_offset methods.

Also update the unit test of interruption to make sure one move
has started before starting the next. The moves were happening
so quickly that the above bug was missed.