### PR TITLE
DM-31724: read and report 3 bus voltages instead of 6 motor currents

### DIFF
--- a/python/lsst/ts/mthexapod/mock_controller.py
+++ b/python/lsst/ts/mthexapod/mock_controller.py
@@ -41,9 +41,10 @@ from . import simple_hexapod
 # The real controller may use 0.15
 TRACK_TIMEOUT = 1
 
-# Model motor current and voltage as proportional to fractional velocity.
+# Model motor current as proportional to fractional velocity
+# and bus voltage as constant
 AMPS_PER_FRAC_SPEED = 1
-VOLTS_PER_FRAC_SPEED = 10
+BUS_VOLTAGE = 100
 
 
 class MockMTHexapodController(hexrotcomm.BaseMockController):
@@ -321,9 +322,7 @@ class MockMTHexapodController(hexrotcomm.BaseMockController):
             # self.telemetry.motor_current[:] = np.multiply(
             #     axes_frac_velocity, AMPS_PER_FRAC_SPEED
             # )
-            # self.telemetry.motor_voltage[:] = np.multiply(
-            #     axes_frac_velocity, VOLTS_PER_FRAC_SPEED
-            # )
+            # self.telemetry.bus_voltage[:] = BUS_VOLTAGE
 
             # state, enabled_substate and offline_substate
             # are all set by set_state

--- a/python/lsst/ts/mthexapod/structs.py
+++ b/python/lsst/ts/mthexapod/structs.py
@@ -130,6 +130,6 @@ class Telemetry(ctypes.Structure):
         # TODO DM-31290: uncomment these lines and move them
         # to the correct location when the data is available
         # ("motor_current", ctypes.c_double * 6),
-        # ("motor_voltage", ctypes.c_double * 6),
+        # ("bus_voltage", ctypes.c_double * 3),
     ]
     FRAME_ID = 0x0

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -792,11 +792,12 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             else:
                 warnings.warn("actuators topic does not have a timestamp field")
 
+            expected_bus_voltage = [mthexapod.mock_controller.BUS_VOLTAGE] * 3
             data = await self.remote.tel_electrical.next(
                 flush=True, timeout=STD_TIMEOUT
             )
             np.testing.assert_allclose(data.motorCurrent, [0] * 6)
-            np.testing.assert_allclose(data.motorVoltage, [0] * 6)
+            np.testing.assert_allclose(data.motorVoltage, expected_bus_voltage)
 
             uncompensated_position = mthexapod.Position(0, 0, 1000, 0, 0, 0)
             await self.remote.cmd_move.set_start(
@@ -810,12 +811,8 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             data = await self.remote.tel_electrical.next(
                 flush=True, timeout=STD_TIMEOUT
             )
-            np.testing.assert_allclose(
-                data.motorCurrent, [mthexapod.mock_controller.AMPS_PER_FRAC_SPEED] * 6
-            )
-            np.testing.assert_allclose(
-                data.motorVoltage, [mthexapod.mock_controller.VOLTS_PER_FRAC_SPEED] * 6
-            )
+            np.testing.assert_array_less([0] * 6, data.motorCurrent)
+            np.testing.assert_allclose(data.motorVoltage, expected_bus_voltage)
 
     async def test_move_no_compensation_no_compensation_inputs(self):
         """Test move with compensation disabled when the CSC has


### PR DESCRIPTION
Note that the code in question is disabled until DM-31290 is implemented.
Also fix a bug in the test of motor current (which did not fail because the test part of the disabled code).