### PR TITLE
Fix the failed test.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ###############
 
+v1.0.4
+------
+
+* Fix the test case: ``test_offset_with_compensation()`` when using Python 3.11.
+* Improve the test case: ``test_move_translate()``.
+
 v1.0.3
 ------
 

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -26,7 +26,6 @@ import dataclasses
 import logging
 import math
 import pathlib
-import sys
 import time
 import unittest
 
@@ -1147,11 +1146,6 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
                 desired_position=desired_uncompensated_position
             )
 
-    # TODO DM-39991 Investigate why this test case hangs in Python 3.11 and
-    #  fix.
-    @pytest.mark.skipif(
-        sys.version_info > (3, 11), reason="requires python3.10 or lower"
-    )
     async def test_offset_with_compensation(self):
         """Test offset with compensation enabled."""
         first_uncompensated_position = mthexapod.Position(
@@ -1212,6 +1206,9 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await asyncio.sleep(sleep_time)
             new_comp_times = self.get_compensation_timestamps()
             assert old_comp_times == new_comp_times
+
+            # Stop the compensation loop task
+            await self.remote.cmd_stop.set_start(timeout=STD_TIMEOUT)
 
     async def test_set_pivot(self):
         """Test the setPivot command."""

--- a/tests/test_simple_hexapod.py
+++ b/tests/test_simple_hexapod.py
@@ -284,6 +284,8 @@ class SimpleHexapodTestCase(unittest.IsolatedAsyncioTestCase):
         # by the amount of the translation.
         translation = (500, -3020, 2500)
         model.move(translation, (0, 0, 0))
+        await self.check_move(model)
+
         np.testing.assert_allclose(model.cmd_pos, translation, atol=1e-7)
         np.testing.assert_allclose(model.cmd_xyzrot, (0, 0, 0), atol=1e-7)
         for cmd_mirror_position, neutral_mirror_position in zip(
@@ -293,8 +295,6 @@ class SimpleHexapodTestCase(unittest.IsolatedAsyncioTestCase):
             np.testing.assert_allclose(
                 cmd_mirror_position, desired_mirror_position, atol=1e-7
             )
-
-        await self.check_move(model)
 
     async def test_move_rotate_about_x_axis(self):
         await self.check_move_rotate_about_one_axis(axis=0)


### PR DESCRIPTION
* Fix the test case: ``test_offset_with_compensation()`` when using Python 3.11.
* Improve the test case: ``test_move_translate()``.