### PR TITLE
OSW-2245: Investigate and fix issue with MTHexapod compensation mode.

### DIFF
--- a/doc/news/OBS-759.bugfix.1.rst
+++ b/doc/news/OBS-759.bugfix.1.rst
@@ -1,0 +1,1 @@
+Mitigated a race condition that could erroneously re-enable the controller if a compensation move was triggered while transitioning to standby.

--- a/doc/news/OBS-759.bugfix.2.rst
+++ b/doc/news/OBS-759.bugfix.2.rst
@@ -1,0 +1,1 @@
+Improved error handling in 'wait_stop' by adding descriptive warnings before raising CancelledError when the controller is not enabled.

--- a/doc/news/OBS-759.bugfix.rst
+++ b/doc/news/OBS-759.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a race condition in the hexapod compensation loop where a controller transition to idle would cause a silent, unrecoverable failure via an unhandled CancellationError.

--- a/doc/news/OBS-759.misc.1.rst
+++ b/doc/news/OBS-759.misc.1.rst
@@ -1,0 +1,1 @@
+Cleaned up log messages in 'idle_timer_monitor' and performed cosmetic updates to the controller enablement logic in '_move'.

--- a/doc/news/OBS-759.misc.rst
+++ b/doc/news/OBS-759.misc.rst
@@ -1,0 +1,1 @@
+Added unit tests to verify that the compensation mechanism remains functional and recoverable after the drivers are transitioned to an idle state.

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -1260,9 +1260,14 @@ Action Required:
                 await self._update_idle_time(count * period)
 
                 if self._idle_time_in_enabled_state >= self.no_movement_idle_time:
+                    self.log.info(
+                        f"Controller idle for {self._idle_time_in_enabled_state}s, "
+                        f"idle time {self.no_movement_idle_time}s; "
+                        "standby controller."
+                    )
+                    self._controller_idle = True
                     await self.standby_controller()
-
-                    self.log.info("Standby the controller after the timeout of no movement when enabled.")
+                    self.log.debug("Controller in standby...")
 
                 count = 0
 

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -204,6 +204,7 @@ class HexapodCsc(hexrotcomm.BaseCsc):
         # Task to monitor the hexapod is in idle or not under the enabled
         # state.
         self.idle_time_monitor_task = make_done_future()
+        self._controller_idle = False
 
         # Record missing compensation inputs we have warned about,
         # to avoid duplicate warnings.
@@ -565,7 +566,15 @@ Action Required:
 
         while self.summary_state == salobj.State.ENABLED:
             try:
-                await self.compensation_wait()
+                try:
+                    await self.compensation_wait()
+                except asyncio.CancelledError:
+                    if self._controller_idle:
+                        self.log.debug("Compensation wait cancelled due to idling controller; continuing...")
+                        await asyncio.sleep(self.compensation_interval)
+                    else:
+                        self.log.info("Compensation cancelled but controller not idle; stopping")
+                        raise
                 self.log.debug("Apply compensation")
                 uncompensated_pos = self._get_uncompensated_position()
                 await self._move(
@@ -1229,6 +1238,7 @@ Action Required:
             )
 
         if self.summary_state == salobj.State.ENABLED:
+            self._controller_idle = False
             self.idle_time_monitor_task = asyncio.create_task(self.idle_time_monitor())
             self.initial_compensation_offset_applied = False
 
@@ -1265,6 +1275,12 @@ Action Required:
                         f"idle time {self.no_movement_idle_time}s; "
                         "standby controller."
                     )
+                    # Note that we mark controller idle as true here
+                    # before standing by the controller on purpose.
+                    # This helps avoid a race condition where the controller
+                    # transitions to standby and there is a cancellation error
+                    # issued by the wait_stopped method while still handling
+                    # the standing by.
                     self._controller_idle = True
                     await self.standby_controller()
                     self.log.debug("Controller in standby...")
@@ -1272,6 +1288,7 @@ Action Required:
                 count = 0
 
         # Reset the idle time when not monitoring
+        self._controller_idle = False
         await self._update_idle_time(0.0)
 
         self.log.info("End the task to monitor the idle time under the enabled state.")
@@ -1587,7 +1604,14 @@ Action Required:
             # self.idle_time_monitor().
             if self.client.telemetry.state != ControllerState.ENABLED:
                 self.log.info("Re-enable controller from idle.")
+                # Here we set controller idle flag after enabling
+                # the controller on purpose, again to avoid a race condition
+                # where there is still controller standby being handled by
+                # the compensation loop. This guarantees it continues to handle
+                # the condition correctly until after the controller is
+                # enabled.
                 await self.enable_controller()
+                self._controller_idle = False
                 self.log.debug("Controller enabled.")
 
             compensation_info = self.compute_compensation(uncompensated_pos)

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -1522,6 +1522,7 @@ Action Required:
             self.telemetry_event.clear()
             await self.telemetry_event.wait()
             if self.client.telemetry.state != ControllerState.ENABLED:
+                self.log.warning("Controller no longer enabled; cancelling wait.")
                 raise asyncio.CancelledError()
             if self.client.telemetry.enabled_substate == EnabledSubstate.STATIONARY:
                 n_telemetry_stopped += 1

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -1598,22 +1598,6 @@ Action Required:
             you want to do the movement in a single step. (the default is 0.0)
         """
         try:
-            # Enable the controller state first if it is not. Note that it
-            # might be put into the Standby state when the CSC is under the
-            # Enabled state without the movement after the timeout by the
-            # self.idle_time_monitor().
-            if self.client.telemetry.state != ControllerState.ENABLED:
-                self.log.info("Re-enable controller from idle.")
-                # Here we set controller idle flag after enabling
-                # the controller on purpose, again to avoid a race condition
-                # where there is still controller standby being handled by
-                # the compensation loop. This guarantees it continues to handle
-                # the condition correctly until after the controller is
-                # enabled.
-                await self.enable_controller()
-                self._controller_idle = False
-                self.log.debug("Controller enabled.")
-
             compensation_info = self.compute_compensation(uncompensated_pos)
 
             if is_compensation_loop:
@@ -1655,6 +1639,25 @@ Action Required:
                         f"{self.camera_shutter_detailed_state=}."
                     )
                 self.initial_compensation_offset_applied = True
+
+            # If we get here it means there is a compensation motion to be
+            # applied.
+            # Enable the controller state first if it is not. Note that it
+            # might be put into the Standby state when the CSC is under the
+            # Enabled state without the movement after the timeout by the
+            # self.idle_time_monitor().
+            if self.client.telemetry.state != ControllerState.ENABLED:
+                self.log.info("Re-enable controller from idle.")
+                # Here we set controller idle flag after enabling
+                # the controller on purpose, again to avoid a race condition
+                # where there is still controller standby being handled by
+                # the compensation loop. This guarantees it continues to handle
+                # the condition correctly until after the controller is
+                # enabled.
+                await self.enable_controller()
+                self._controller_idle = False
+                self.log.debug("Controller enabled.")
+
             # Stop the current motion, if any, and wait for it to stop.
             await asyncio.wait_for(self.stop_motion(), timeout=MAXIMUM_STOP_TIME)
 

--- a/python/lsst/ts/mthexapod/hexapod_csc.py
+++ b/python/lsst/ts/mthexapod/hexapod_csc.py
@@ -1586,9 +1586,9 @@ Action Required:
             # Enabled state without the movement after the timeout by the
             # self.idle_time_monitor().
             if self.client.telemetry.state != ControllerState.ENABLED:
+                self.log.info("Re-enable controller from idle.")
                 await self.enable_controller()
-
-                self.log.info("Re-enable the controller from the idle.")
+                self.log.debug("Controller enabled.")
 
             compensation_info = self.compute_compensation(uncompensated_pos)
 

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -98,6 +98,10 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             # self.mtrotator_controller = mtrotator_controller
             # self.ess_temperature_controller = ess_temperature_controller
             yield
+            try:
+                await salobj.set_summary_state(self.remote, salobj.State.STANDBY)
+            except Exception:
+                pass
 
     async def assert_next_application(self, desired_position: mthexapod.Position) -> None:
         """Wait for and check the next application telemetry.
@@ -1654,6 +1658,95 @@ class TestHexapodCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await asyncio.sleep(2.0)
 
             assert self.csc.idle_time_monitor_task.done() is True
+
+    async def test_compensation_after_drives_idle(self) -> None:
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            override="",
+            simulation_mode=1,
+        ):
+            await self.assert_initial_compensation_values()
+
+            compensation_inputs_list = (
+                mthexapod.CompensationInputs(elevation=32, azimuth=44, rotation=-5, temperature=15),
+                mthexapod.CompensationInputs(elevation=65, azimuth=44, rotation=-5, temperature=15),
+                mthexapod.CompensationInputs(elevation=32, azimuth=190, rotation=-5, temperature=15),
+                mthexapod.CompensationInputs(elevation=32, azimuth=44, rotation=20, temperature=15),
+                mthexapod.CompensationInputs(elevation=32, azimuth=44, rotation=-5, temperature=-30),
+            )
+            await self.set_compensation_inputs(**vars(compensation_inputs_list[0]))
+
+            await self.assert_next_sample(topic=self.remote.evt_compensationMode, enabled=False)
+            await self.remote.cmd_setCompensationMode.set_start(enable=True, timeout=STD_TIMEOUT)
+            await self.assert_next_sample(topic=self.remote.evt_compensationMode, enabled=True)
+
+            uncompensated_position = mthexapod.Position(500, -300, 200, 0.03, -0.02, 0.03)
+            await self.check_move(
+                uncompensated_position=uncompensated_position,
+                est_move_duration=1,
+            )
+
+            update_inputs = False
+            for compensation_inputs in compensation_inputs_list:
+                with self.subTest(compensation_inputs=compensation_inputs):
+                    await self.check_compensation(
+                        uncompensated_position=uncompensated_position,
+                        compensation_inputs=compensation_inputs,
+                        update_inputs=update_inputs,
+                    )
+                    update_inputs = True
+
+            # Try finite inputs again; this should work.
+            await self.check_compensation(
+                uncompensated_position=uncompensated_position,
+                compensation_inputs=compensation_inputs_list[-2],
+                update_inputs=True,
+            )
+
+            # Wait for controller to idle
+            self.remote.evt_controllerState.flush()
+
+            # Task should be running
+            assert self.csc.idle_time_monitor_task.done() is False
+
+            while True:
+                try:
+                    controller_state = await self.assert_next_sample(
+                        topic=self.remote.evt_controllerState,
+                        timeout=1,
+                    )
+                    print(
+                        f"{ControllerState(controller_state.controllerState)!r} "
+                        f"{EnabledSubstate(controller_state.enabledSubstate)!r}"
+                    )
+                except asyncio.TimeoutError:
+                    break
+
+            # Controller should be put into idle after timeout
+            self.csc.config.camera_config["no_movement_idle_time"] = 9.0
+            await asyncio.sleep(self.csc.config.camera_config["no_movement_idle_time"] + 1)
+
+            await self.assert_next_sample(
+                topic=self.remote.evt_controllerState,
+                controllerState=ControllerState.STANDBY,
+                enabledSubstate=EnabledSubstate.STATIONARY,
+            )
+
+            # compensation should wake up the controller and be applied
+            update_inputs = True
+            for compensation_inputs in compensation_inputs_list:
+                with self.subTest(compensation_inputs=compensation_inputs):
+                    await self.check_compensation(
+                        uncompensated_position=uncompensated_position,
+                        compensation_inputs=compensation_inputs,
+                        update_inputs=update_inputs,
+                    )
+                    if update_inputs:
+                        await self.assert_next_sample(
+                            topic=self.remote.evt_controllerState,
+                            controllerState=ControllerState.ENABLED,
+                        )
+                    update_inputs = True
 
     async def test_apply_compensation_while_exposing(self) -> None:
         initial_filter = "r_03"


### PR DESCRIPTION
I was able to trace this issue back to a race condition in the compensation loop. 

If the CSC put the driver in standby when the compensation loop was waiting for the hexapod to be stopped, it would trigger a cancellation error that would not be correctly captured and handled by the controller. If, on the other hand, the controller was sent to standby when waiting for the compensation interval, the process would work fine at `compensation_wait` would return instead of raising a cancellation.

To mitigate this I ensured the CSC is keeping track of when it put the controller in standby and handles the cancellation correctly when waiting for compensation.

Note that there is still a much rarer race condition in the ts_hexrotcomm when putting the controller in standby and enable. The `BaseCSC` is not locking on this operation, only when writing the command. That means a Standby can be issued while Enabling and vice versa. I was able to reproduce this a few times but only ~1 in 100. I think however, that this is what is triggering the issue we see occasionally at the summit when, internally, the CSC has compensation off while the last published value is on.

This patch made this error a lot more rare than before; I haven't been able to reproduce it after running it hundreds of times. However I would also like to patch ts_hexrotcomm to protect against this condition. 